### PR TITLE
remove needless alias

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -24,12 +24,11 @@ alias ls="ls -ap ${colorflag}"
 
 # Start a SimpleHTTPServer on 127.0.0.1 (rather than the default 0.0.0.0). The
 # first argument after the command can be provided to change the port.
-http () {
+server() {
   PORT=${1:-8000}
   echo "Serving HTTP on 127.0.0.1 port ${PORT} ..."
   python -c "import BaseHTTPServer as bhs, SimpleHTTPServer as shs; bhs.HTTPServer(('127.0.0.1', ${PORT}), shs.SimpleHTTPRequestHandler).serve_forever()"
 }
-alias server=http
 
 export CLICOLOR=1
 export LSCOLORS=gxBxhxDxfxhxhxhxhxcxcx


### PR DESCRIPTION
Signed-off-by: Ryan P.C. McQuen <ryan.q@linux.com>

Functions are already sourced, no need to alias.  ;-)